### PR TITLE
chore: upgrade to next15

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AI-powered recipe book and meal planner Progressive Web App.
 
 ## Development
 
-This repository hosts a minimal Next.js 14 app configured with the App Router, TypeScript, and Tailwind CSS.
+This repository hosts a minimal Next.js 15 app configured with the App Router, TypeScript, and Tailwind CSS.
 
 ### Prerequisites
 

--- a/docs/PROJECT_PROMPT.md
+++ b/docs/PROJECT_PROMPT.md
@@ -41,7 +41,7 @@ Build a fast, offlineâ€‘capable Progressive Web App that becomes a personal, AIâ
 
 ## 4) Tech Stack & Hosting
 
-* **Framework**: Next.js 14+ (App Router) + TypeScript.
+* **Framework**: Next.js 15+ (App Router) + TypeScript.
 * **UI**: Tailwind CSS + shadcn/ui + Radix primitives.
 * **State**: React Server Components (RSC) + server actions; client state via Zustand or React Query for optimistic updates.
 * **DB**: Postgres (Vercel Postgres or Neon) + Prisma.

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "test": "echo 'Error: no test specified' && exit 1"
   },
   "dependencies": {
-    "next": "14.2.3",
+    "next": "15.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",
     "eslint": "9.0.0",
-    "eslint-config-next": "14.2.3",
+    "eslint-config-next": "15.0.0",
     "postcss": "8.4.31",
     "tailwindcss": "3.4.1",
     "typescript": "5.5.4"


### PR DESCRIPTION
## Summary
- bump Next.js to v15 and align ESLint config
- update documentation to reflect Next.js 15 usage

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689609f844ec832ea076b5649af03670