### PR TITLE
feat: add recipe ingestion workflows

### DIFF
--- a/src/app/api/nutrition/calculate/route.ts
+++ b/src/app/api/nutrition/calculate/route.ts
@@ -1,7 +1,11 @@
+import { estimateNutrition } from '@/lib/nutrition';
+
 export async function POST(req: Request) {
   const { ingredients } = await req.json();
-  if (!ingredients) {
+  if (!ingredients || !Array.isArray(ingredients)) {
     return Response.json({ error: 'Missing ingredients' }, { status: 400 });
   }
-  return Response.json({ calories: 0, macros: { protein: 0, fat: 0, carbs: 0 } });
+
+  const nutrition = await estimateNutrition(ingredients);
+  return Response.json(nutrition);
 }

--- a/src/app/api/recipes/generate/route.ts
+++ b/src/app/api/recipes/generate/route.ts
@@ -1,7 +1,25 @@
+import { openai } from '@/lib/openai';
+import { estimateNutrition } from '@/lib/nutrition';
+
 export async function POST(req: Request) {
   const { prompt } = await req.json();
   if (!prompt) {
     return Response.json({ error: 'Missing prompt' }, { status: 400 });
   }
-  return Response.json({ recipe: { title: 'Generated Recipe', prompt } });
+
+  const response = await openai.responses.create({
+    model: 'gpt-4o-mini',
+    input: `Generate a recipe in JSON format with fields title, description, yield, ingredients (array), steps (array) based on the following description. Return only JSON.\n\n${prompt}`,
+  });
+  const text = (response as any).output_text || (response as any).choices?.[0]?.message?.content || '{}';
+  let recipe: any;
+  try {
+    recipe = JSON.parse(text);
+  } catch {
+    return Response.json({ error: 'Failed to generate recipe' }, { status: 500 });
+  }
+
+  recipe.nutrition = await estimateNutrition(recipe.ingredients || []);
+
+  return Response.json({ recipe });
 }

--- a/src/app/api/recipes/ingest/route.ts
+++ b/src/app/api/recipes/ingest/route.ts
@@ -1,7 +1,29 @@
+import { prisma } from '@/lib/prisma';
+
 export async function POST(req: Request) {
-  const { source, data } = await req.json();
-  if (!source || !data) {
-    return Response.json({ error: 'Missing source or data' }, { status: 400 });
+  const { source, data, ownerId } = await req.json();
+  if (!source || !data || !ownerId) {
+    return Response.json({ error: 'Missing source, data, or ownerId' }, { status: 400 });
   }
-  return Response.json({ id: 'recipe_stub', source });
+
+  const recipe = await prisma.recipe.create({
+    data: {
+      ownerId,
+      title: data.title,
+      description: data.description,
+      yield: data.yield,
+      prepMinutes: data.prepMinutes,
+      cookMinutes: data.cookMinutes,
+      totalMinutes: data.totalMinutes,
+      ingredients: data.ingredients,
+      steps: data.steps,
+      equipment: data.equipment || [],
+      tags: data.tags || [],
+      nutrition: data.nutrition,
+      images: data.images || [],
+      source: { type: source, url: data.sourceUrl },
+    },
+  });
+
+  return Response.json({ id: recipe.id, source });
 }

--- a/src/app/api/recipes/parse/route.ts
+++ b/src/app/api/recipes/parse/route.ts
@@ -1,7 +1,69 @@
+import { scrape } from '@/lib/scrape';
+import { openai } from '@/lib/openai';
+import { uploadFile } from '@/lib/upload';
+import { estimateNutrition } from '@/lib/nutrition';
+
+interface ParsedRecipe {
+  title: string;
+  description?: string;
+  yield?: string;
+  ingredients: string[];
+  steps: string[];
+  images?: string[];
+  nutrition?: any;
+}
+
 export async function POST(req: Request) {
   const { url, image } = await req.json();
   if (!url && !image) {
     return Response.json({ error: 'Provide a url or image' }, { status: 400 });
   }
-  return Response.json({ ok: true, parsed: { title: 'Example Recipe' } });
+
+  let recipe: ParsedRecipe | null = null;
+
+  if (url) {
+    const html = await scrape(url);
+    const response = await openai.responses.create({
+      model: 'gpt-4o-mini',
+      input: `Extract a recipe as JSON with fields title, description, yield, ingredients (array), steps (array) from the following HTML. Return only JSON.\n\n${html}`,
+    });
+    const text = (response as any).output_text || (response as any).choices?.[0]?.message?.content || '{}';
+    try {
+      recipe = JSON.parse(text);
+    } catch {
+      return Response.json({ error: 'Failed to parse recipe' }, { status: 500 });
+    }
+    recipe.images = [url];
+  } else if (image) {
+    const buffer = Buffer.from(image, 'base64');
+    const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+    const upload = await uploadFile(`uploads/${Date.now()}.png`, arrayBuffer);
+    const response = await openai.responses.create({
+      model: 'gpt-4o-mini',
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Extract recipe information as JSON.' },
+            { type: 'input_image', image_url: `data:image/png;base64,${image}` },
+          ],
+        },
+      ],
+    });
+    const text = (response as any).output_text || (response as any).choices?.[0]?.message?.content || '{}';
+    try {
+      recipe = JSON.parse(text);
+    } catch {
+      return Response.json({ error: 'Failed to parse recipe' }, { status: 500 });
+    }
+    recipe.images = [upload.url];
+  }
+
+  if (!recipe) {
+    return Response.json({ error: 'Unable to parse recipe' }, { status: 500 });
+  }
+
+  recipe.nutrition = await estimateNutrition(recipe.ingredients);
+
+  return Response.json({ ok: true, parsed: recipe });
 }

--- a/src/lib/nutrition.ts
+++ b/src/lib/nutrition.ts
@@ -1,0 +1,33 @@
+import { openai } from './openai';
+
+export interface NutritionEstimate {
+  calories: number;
+  macros: {
+    protein: number;
+    fat: number;
+    carbs: number;
+  };
+}
+
+/**
+ * Use OpenAI to estimate nutrition information for an ingredient list.
+ * Falls back to zero values if the model response can't be parsed.
+ */
+export async function estimateNutrition(ingredients: string[]): Promise<NutritionEstimate> {
+  const prompt = `Estimate total calories and macronutrients (protein, fat, carbs in grams) for the following ingredients: ${ingredients.join(
+    ', '
+  )}. Respond with JSON {"calories":number,"macros":{"protein":number,"fat":number,"carbs":number}}`;
+
+  const response = await openai.responses.create({
+    model: 'gpt-4o-mini',
+    input: prompt,
+  });
+
+  const text = (response as any).output_text || (response as any).choices?.[0]?.message?.content || '{}';
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { calories: 0, macros: { protein: 0, fat: 0, carbs: 0 } };
+  }
+}


### PR DESCRIPTION
## Summary
- add OpenAI-powered nutrition estimator
- support recipe parsing from images and URLs with OCR and scraping
- enable natural-language recipe generation and database ingestion

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689615adc1fc832e8a22cf57592a9ebf