### PR TITLE
feat: enhance recipe management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,8 @@ model User {
   createdAt  DateTime           @default(now())
   recipes    Recipe[]
   shoppingLists ShoppingList[]
+  favorites  RecipeFavorite[]
+  ratings    RecipeRating[]
 }
 
 model Household {
@@ -62,6 +64,9 @@ model Recipe {
   embedding    Bytes?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  favorites    RecipeFavorite[]
+  ratings      RecipeRating[]
+  versions     RecipeVersion[]
 }
 
 model MealPlan {
@@ -82,5 +87,40 @@ model ShoppingList {
   createdAt DateTime @default(now())
   plan      MealPlan? @relation(fields: [planId], references: [id])
   owner     User      @relation(fields: [ownerId], references: [id])
+}
+
+model RecipeFavorite {
+  id        String   @id @default(cuid())
+  userId    String
+  recipeId  String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+  recipe    Recipe   @relation(fields: [recipeId], references: [id])
+
+  @@unique([userId, recipeId])
+}
+
+model RecipeRating {
+  id        String   @id @default(cuid())
+  userId    String
+  recipeId  String
+  rating    Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id])
+  recipe    Recipe   @relation(fields: [recipeId], references: [id])
+
+  @@unique([userId, recipeId])
+}
+
+model RecipeVersion {
+  id        String   @id @default(cuid())
+  recipeId  String
+  version   Int
+  data      Json
+  createdAt DateTime @default(now())
+  recipe    Recipe   @relation(fields: [recipeId], references: [id])
+
+  @@unique([recipeId, version])
 }
 

--- a/src/app/api/recipes/[id]/favorite/route.ts
+++ b/src/app/api/recipes/[id]/favorite/route.ts
@@ -1,0 +1,26 @@
+import { prisma } from '@/lib/prisma';
+
+// Toggle favorite status for a recipe
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { userId, favorite } = await req.json();
+  if (!userId) {
+    return Response.json({ error: 'Missing userId' }, { status: 400 });
+  }
+
+  if (favorite) {
+    await prisma.recipeFavorite.upsert({
+      where: { userId_recipeId: { userId, recipeId: params.id } },
+      update: {},
+      create: { userId, recipeId: params.id },
+    });
+  } else {
+    await prisma.recipeFavorite.deleteMany({
+      where: { userId, recipeId: params.id },
+    });
+  }
+
+  return Response.json({ ok: true });
+}

--- a/src/app/api/recipes/[id]/rate/route.ts
+++ b/src/app/api/recipes/[id]/rate/route.ts
@@ -1,0 +1,30 @@
+import { prisma } from '@/lib/prisma';
+
+// Set or update a user's rating for a recipe
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const { userId, rating } = await req.json();
+  if (!userId || typeof rating !== 'number') {
+    return Response.json({ error: 'Missing userId or rating' }, { status: 400 });
+  }
+
+  await prisma.recipeRating.upsert({
+    where: { userId_recipeId: { userId, recipeId: params.id } },
+    update: { rating },
+    create: { userId, recipeId: params.id, rating },
+  });
+
+  const aggregate = await prisma.recipeRating.aggregate({
+    where: { recipeId: params.id },
+    _avg: { rating: true },
+    _count: { rating: true },
+  });
+
+  return Response.json({
+    ok: true,
+    average: aggregate._avg.rating,
+    count: aggregate._count.rating,
+  });
+}

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -1,0 +1,43 @@
+import { prisma } from '@/lib/prisma';
+import { autoTagRecipe } from '@/lib/tags';
+import { embedRecipe } from '@/lib/embedding';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const recipe = await prisma.recipe.findUnique({ where: { id: params.id } });
+  if (!recipe) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+  return Response.json({ recipe });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } },
+) {
+  const data = await req.json();
+  const existing = await prisma.recipe.findUnique({ where: { id: params.id } });
+  if (!existing) {
+    return Response.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  await prisma.recipeVersion.create({
+    data: {
+      recipeId: existing.id,
+      version: existing.version,
+      data: existing,
+    },
+  });
+
+  const merged = { ...existing, ...data };
+  const tags = merged.tags && merged.tags.length ? merged.tags : autoTagRecipe(merged);
+  const embedding = await embedRecipe({ ...merged, tags });
+
+  const updated = await prisma.recipe.update({
+    where: { id: params.id },
+    data: { ...data, tags, embedding: embedding ?? undefined, version: existing.version + 1 },
+  });
+  return Response.json({ recipe: updated });
+}

--- a/src/app/api/recipes/[id]/versions/route.ts
+++ b/src/app/api/recipes/[id]/versions/route.ts
@@ -1,0 +1,13 @@
+import { prisma } from '@/lib/prisma';
+
+// Retrieve version history for a recipe
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const versions = await prisma.recipeVersion.findMany({
+    where: { recipeId: params.id },
+    orderBy: { version: 'desc' },
+  });
+  return Response.json({ versions });
+}

--- a/src/app/api/recipes/generate/route.ts
+++ b/src/app/api/recipes/generate/route.ts
@@ -1,5 +1,6 @@
 import { openai } from '@/lib/openai';
 import { estimateNutrition } from '@/lib/nutrition';
+import { autoTagRecipe } from '@/lib/tags';
 
 export async function POST(req: Request) {
   const { prompt } = await req.json();
@@ -20,6 +21,7 @@ export async function POST(req: Request) {
   }
 
   recipe.nutrition = await estimateNutrition(recipe.ingredients || []);
+  recipe.tags = autoTagRecipe(recipe);
 
   return Response.json({ recipe });
 }

--- a/src/app/api/recipes/parse/route.ts
+++ b/src/app/api/recipes/parse/route.ts
@@ -2,6 +2,7 @@ import { scrape } from '@/lib/scrape';
 import { openai } from '@/lib/openai';
 import { uploadFile } from '@/lib/upload';
 import { estimateNutrition } from '@/lib/nutrition';
+import { autoTagRecipe } from '@/lib/tags';
 
 interface ParsedRecipe {
   title: string;
@@ -64,6 +65,7 @@ export async function POST(req: Request) {
   }
 
   recipe.nutrition = await estimateNutrition(recipe.ingredients);
+  recipe.tags = autoTagRecipe(recipe);
 
   return Response.json({ ok: true, parsed: recipe });
 }

--- a/src/app/api/recipes/search/route.ts
+++ b/src/app/api/recipes/search/route.ts
@@ -1,0 +1,41 @@
+import { prisma } from '@/lib/prisma';
+import { createEmbedding } from '@/lib/embedding';
+
+// Simple full-text and semantic search endpoint for recipes.
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') || '';
+  const tags = searchParams.getAll('tag');
+  const semantic = searchParams.get('semantic');
+
+  const where: any = {};
+  if (q && !semantic) {
+    where.OR = [
+      { title: { contains: q, mode: 'insensitive' } },
+      { description: { contains: q, mode: 'insensitive' } },
+    ];
+  }
+  if (tags.length) {
+    where.tags = { hasEvery: tags };
+  }
+
+  if (semantic && q) {
+    const embedding = await createEmbedding(q);
+    if (!embedding) {
+      return Response.json({ recipes: [] });
+    }
+    const recipes = await prisma.$queryRawUnsafe(
+      `SELECT id, title, description, tags FROM "Recipe" ORDER BY embedding <-> $1 LIMIT 20`,
+      embedding,
+    );
+    return Response.json({ recipes });
+  }
+
+  const recipes = await prisma.recipe.findMany({
+    where,
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+    select: { id: true, title: true, description: true, tags: true },
+  });
+  return Response.json({ recipes });
+}

--- a/src/lib/embedding.ts
+++ b/src/lib/embedding.ts
@@ -1,0 +1,38 @@
+import { openai } from './openai';
+
+// Create an embedding buffer from text using OpenAI embeddings API.
+export async function createEmbedding(text: string): Promise<Buffer | null> {
+  try {
+    const res = await openai.embeddings.create({
+      model: 'text-embedding-3-small',
+      input: text,
+    });
+    const array = new Float32Array(res.data[0].embedding);
+    return Buffer.from(array.buffer);
+  } catch (err) {
+    console.error('embedding error', err);
+    return null;
+  }
+}
+
+export function recipeToEmbeddingText(recipe: {
+  title?: string;
+  description?: string;
+  ingredients?: any[];
+  tags?: string[];
+}): string {
+  const ingredients = Array.isArray(recipe.ingredients)
+    ? recipe.ingredients.map((i) => i.name || '').join(' ')
+    : '';
+  return `${recipe.title ?? ''}\n${recipe.description ?? ''}\n${(recipe.tags || []).join(' ')}\n${ingredients}`;
+}
+
+export async function embedRecipe(recipe: {
+  title?: string;
+  description?: string;
+  ingredients?: any[];
+  tags?: string[];
+}): Promise<Buffer | null> {
+  const text = recipeToEmbeddingText(recipe);
+  return createEmbedding(text);
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,33 @@
+import type { Recipe } from '@prisma/client';
+
+// Naive tag generator based on recipe content. In a real application
+// this would use an AI model or more advanced NLP.
+export function autoTagRecipe(recipe: {
+  title?: string;
+  ingredients?: any[];
+  steps?: any[];
+}): string[] {
+  const text = `${recipe.title ?? ''} ` +
+    `${(recipe.ingredients || []).map(i => i.name || '').join(' ')} ` +
+    `${(recipe.steps || []).join(' ')}`.toLowerCase();
+
+  const tags = new Set<string>();
+
+  const cuisines: Record<string, RegExp> = {
+    mexican: /taco|quesadilla|enchilada|salsa/, 
+    italian: /pasta|risotto|spaghetti|lasagna/, 
+    indian: /curry|masala|paneer|tikka/, 
+    chinese: /noodle|dumpling|szechuan|fried rice/,
+  };
+
+  for (const [tag, regex] of Object.entries(cuisines)) {
+    if (regex.test(text)) tags.add(tag);
+  }
+
+  if (/salad|lettuce|spinach|kale/.test(text)) tags.add('salad');
+  if (/cake|cookie|dessert|brownie|pie/.test(text)) tags.add('dessert');
+  if (/chicken|beef|pork|fish|shrimp/.test(text)) tags.add('protein');
+  if (!/(beef|pork|chicken|fish|shrimp)/.test(text)) tags.add('vegetarian');
+
+  return Array.from(tags);
+}


### PR DESCRIPTION
## Summary
- add favorites, ratings, and version-tracking models to Prisma schema
- implement auto tag generation and embedding helpers for semantic search
- introduce recipe search, favorite/rate endpoints, and versioned updates

## Testing
- `npx prisma format` (fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_6896172f4d5c832e8c1c2b365f6f722a