### PR TITLE
feat: add AI meal planner

### DIFF
--- a/src/app/(app)/meal-plan/page.tsx
+++ b/src/app/(app)/meal-plan/page.tsx
@@ -1,8 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { MealPlan, MealSlot } from '@/lib/mealPlan';
+import { MEAL_SLOTS, calculateShoppingList } from '@/lib/mealPlan';
+
 export default function MealPlanPage() {
+  const [constraints, setConstraints] = useState('');
+  const [plan, setPlan] = useState<MealPlan | null>(null);
+  const [shoppingList, setShoppingList] = useState<string[]>([]);
+  const [drag, setDrag] = useState<{ day: number; slot: MealSlot } | null>(null);
+
+  const generate = async () => {
+    const res = await fetch('/api/meal-plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ constraints }),
+    });
+    const data = await res.json();
+    setPlan(data.plan);
+  };
+
+  useEffect(() => {
+    if (plan) {
+      setShoppingList(calculateShoppingList(plan));
+    }
+  }, [plan]);
+
+  const onDragStart = (day: number, slot: MealSlot) => () => {
+    setDrag({ day, slot });
+  };
+
+  const onDrop = (day: number, slot: MealSlot) => (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!plan || !drag) return;
+    const next = plan.map((d) => ({ ...d, meals: { ...d.meals } }));
+    const recipe = next[drag.day].meals[drag.slot];
+    next[drag.day].meals[drag.slot] = next[day].meals[slot];
+    next[day].meals[slot] = recipe;
+    setPlan(next);
+    setDrag(null);
+  };
+
+  const allowDrop = (e: React.DragEvent) => e.preventDefault();
+
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold">Meal Plan</h1>
       <p className="mt-2">Generate and edit your weekly meal plans.</p>
+
+      <div className="mt-4 flex gap-2">
+        <input
+          className="border p-2 flex-1"
+          value={constraints}
+          onChange={(e) => setConstraints(e.target.value)}
+          placeholder="Dietary constraints (e.g. vegan, gluten-free)"
+        />
+        <button
+          onClick={generate}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Generate
+        </button>
+      </div>
+
+      {plan && (
+        <>
+          <div className="grid grid-cols-7 gap-2 mt-4">
+            {plan.map((day, di) => (
+              <div key={day.day} className="border p-2">
+                <h3 className="font-semibold text-center">{day.day}</h3>
+                {MEAL_SLOTS.map((slot) => (
+                  <div
+                    key={slot}
+                    className="border p-1 mt-1 min-h-[40px]"
+                    draggable={!!day.meals[slot]}
+                    onDragStart={onDragStart(di, slot)}
+                    onDragOver={allowDrop}
+                    onDrop={onDrop(di, slot)}
+                  >
+                    {day.meals[slot]?.title || (
+                      <span className="text-gray-400">{slot}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6">
+            <h2 className="text-xl font-bold">Shopping List</h2>
+            <ul className="list-disc pl-6">
+              {shoppingList.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
     </main>
   );
 }

--- a/src/app/api/meal-plan/route.ts
+++ b/src/app/api/meal-plan/route.ts
@@ -1,0 +1,10 @@
+import { generateMealPlan } from '@/lib/mealPlan';
+
+export async function POST(req: Request) {
+  const { constraints } = await req.json();
+  if (typeof constraints !== 'string') {
+    return Response.json({ error: 'Missing constraints' }, { status: 400 });
+  }
+  const plan = await generateMealPlan(constraints);
+  return Response.json({ plan });
+}

--- a/src/lib/mealPlan.ts
+++ b/src/lib/mealPlan.ts
@@ -1,0 +1,69 @@
+import { openai } from './openai';
+
+export interface Recipe {
+  id: string;
+  title: string;
+  ingredients: string[];
+  tags: string[];
+}
+
+export type MealSlot = 'breakfast' | 'lunch' | 'dinner';
+
+export interface DayPlan {
+  day: string;
+  meals: Record<MealSlot, Recipe | null>;
+}
+
+export type MealPlan = DayPlan[];
+
+export const MEAL_SLOTS: MealSlot[] = ['breakfast', 'lunch', 'dinner'];
+const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+const SAMPLE_RECIPES: Recipe[] = [
+  { id: 'r1', title: 'Vegan Tacos', ingredients: ['tortillas', 'beans', 'salsa'], tags: ['vegan'] },
+  { id: 'r2', title: 'Grilled Chicken', ingredients: ['chicken', 'lettuce', 'tomatoes'], tags: ['gluten-free'] },
+  { id: 'r3', title: 'Pasta Primavera', ingredients: ['pasta', 'tomato sauce', 'vegetables'], tags: [] },
+];
+
+export async function generateMealPlan(constraints: string): Promise<MealPlan> {
+  try {
+    if (process.env.OPENAI_API_KEY) {
+      const response = await openai.responses.create({
+        model: 'gpt-4o-mini',
+        input: `Create a 7 day meal plan with breakfast, lunch and dinner for each day. Respect these dietary constraints: ${constraints}. Return JSON in format { days: [ { day: "Monday", meals: { breakfast: { title: string, ingredients: string[] }, lunch: {...}, dinner: {...} } } ] }`,
+      });
+      const text = (response as any).output_text || (response as any).choices?.[0]?.message?.content || '{}';
+      const json = JSON.parse(text);
+      if (Array.isArray(json.days)) {
+        return json.days as MealPlan;
+      }
+    }
+  } catch {
+    // fall back to local generation
+  }
+
+  const diets = constraints.toLowerCase().split(/[\s,]+/).filter(Boolean);
+  const allowed = diets.length
+    ? SAMPLE_RECIPES.filter((r) => diets.every((d) => r.tags.includes(d)))
+    : SAMPLE_RECIPES;
+
+  return DAYS.map((day, i) => ({
+    day,
+    meals: {
+      breakfast: allowed[i % allowed.length] || null,
+      lunch: allowed[(i + 1) % allowed.length] || null,
+      dinner: allowed[(i + 2) % allowed.length] || null,
+    },
+  }));
+}
+
+export function calculateShoppingList(plan: MealPlan): string[] {
+  const items = new Set<string>();
+  plan.forEach((day) => {
+    MEAL_SLOTS.forEach((slot) => {
+      const recipe = day.meals[slot];
+      recipe?.ingredients.forEach((ing) => items.add(ing));
+    });
+  });
+  return Array.from(items);
+}


### PR DESCRIPTION
## Summary
- add server-side meal plan generator with OpenAI fallback logic
- expose meal plan API and client page with drag-and-drop editing
- auto-calc shopping list from planned recipes

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: No matching version found for @radix-ui/react-dropdown-menu@^1.1.4)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896198de818832e8b765621408144c0