### PR TITLE
feat: add shopping list and pantry utilities

### DIFF
--- a/src/app/(app)/meal-plan/page.tsx
+++ b/src/app/(app)/meal-plan/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { MealPlan, MealSlot } from '@/lib/mealPlan';
+import type { MealPlan, MealSlot, ShoppingList } from '@/lib/mealPlan';
 import { MEAL_SLOTS, calculateShoppingList } from '@/lib/mealPlan';
 
 export default function MealPlanPage() {
   const [constraints, setConstraints] = useState('');
   const [plan, setPlan] = useState<MealPlan | null>(null);
-  const [shoppingList, setShoppingList] = useState<string[]>([]);
+  const [shoppingList, setShoppingList] = useState<ShoppingList>({});
   const [drag, setDrag] = useState<{ day: number; slot: MealSlot } | null>(null);
 
   const generate = async () => {
@@ -87,14 +87,22 @@ export default function MealPlanPage() {
             ))}
           </div>
 
-          <div className="mt-6">
-            <h2 className="text-xl font-bold">Shopping List</h2>
-            <ul className="list-disc pl-6">
-              {shoppingList.map((item) => (
-                <li key={item}>{item}</li>
+            <div className="mt-6">
+              <h2 className="text-xl font-bold">Shopping List</h2>
+              {Object.entries(shoppingList).map(([section, items]) => (
+                <div key={section} className="mt-2">
+                  <h3 className="font-semibold">{section}</h3>
+                  <ul className="list-disc pl-6">
+                    {items.map((item) => (
+                      <li key={item.name}>
+                        {item.quantity}
+                        {item.unit ? ` ${item.unit}` : ''} {item.name}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               ))}
-            </ul>
-          </div>
+            </div>
         </>
       )}
     </main>

--- a/src/app/(app)/pantry/page.tsx
+++ b/src/app/(app)/pantry/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import type { PantryItem } from '@/lib/pantry';
+import { addToPantry, getAllergenWarnings } from '@/lib/pantry';
+
+const HOUSEHOLD_ALLERGENS = ['peanut', 'gluten'];
+
+export default function PantryPage() {
+  const [pantry, setPantry] = useState<PantryItem[]>([]);
+  const [name, setName] = useState('');
+  const [section, setSection] = useState('');
+  const [allergens, setAllergens] = useState('');
+
+  const add = () => {
+    if (!name) return;
+    const item: PantryItem = {
+      name,
+      quantity: 1,
+      section,
+      allergens: allergens
+        .split(',')
+        .map((a) => a.trim().toLowerCase())
+        .filter(Boolean),
+    };
+    setPantry((p) => addToPantry(p, [item]));
+    setName('');
+    setSection('');
+    setAllergens('');
+  };
+
+  const warnings = getAllergenWarnings(pantry, HOUSEHOLD_ALLERGENS);
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Pantry</h1>
+      <div className="mt-4 flex gap-2">
+        <input
+          className="border p-2 flex-1"
+          placeholder="item"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="section"
+          value={section}
+          onChange={(e) => setSection(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="allergens"
+          value={allergens}
+          onChange={(e) => setAllergens(e.target.value)}
+        />
+        <button
+          onClick={add}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Add
+        </button>
+      </div>
+
+      {warnings.length > 0 && (
+        <div className="mt-4 text-red-600">
+          <h2 className="font-semibold">Allergen Warnings</h2>
+          <ul className="list-disc pl-6">
+            {warnings.map((w) => (
+              <li key={w.item.name}>
+                {w.item.name}: {w.allergens.join(', ')}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <ul className="mt-4 list-disc pl-6">
+        {pantry.map((p) => (
+          <li key={p.name}>
+            {p.name} {p.section && `(${p.section})`}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/src/lib/mealPlan.ts
+++ b/src/lib/mealPlan.ts
@@ -1,9 +1,17 @@
 import { openai } from './openai';
 
+export interface Ingredient {
+  name: string;
+  quantity: number;
+  unit?: string;
+  section?: string;
+  allergens?: string[];
+}
+
 export interface Recipe {
   id: string;
   title: string;
-  ingredients: string[];
+  ingredients: Ingredient[];
   tags: string[];
 }
 
@@ -20,9 +28,36 @@ export const MEAL_SLOTS: MealSlot[] = ['breakfast', 'lunch', 'dinner'];
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
 const SAMPLE_RECIPES: Recipe[] = [
-  { id: 'r1', title: 'Vegan Tacos', ingredients: ['tortillas', 'beans', 'salsa'], tags: ['vegan'] },
-  { id: 'r2', title: 'Grilled Chicken', ingredients: ['chicken', 'lettuce', 'tomatoes'], tags: ['gluten-free'] },
-  { id: 'r3', title: 'Pasta Primavera', ingredients: ['pasta', 'tomato sauce', 'vegetables'], tags: [] },
+  {
+    id: 'r1',
+    title: 'Vegan Tacos',
+    ingredients: [
+      { name: 'tortillas', quantity: 8, unit: 'pieces', section: 'Grains' },
+      { name: 'beans', quantity: 2, unit: 'cups', section: 'Canned', allergens: ['legume'] },
+      { name: 'salsa', quantity: 1, unit: 'jar', section: 'Produce' },
+    ],
+    tags: ['vegan'],
+  },
+  {
+    id: 'r2',
+    title: 'Grilled Chicken',
+    ingredients: [
+      { name: 'chicken', quantity: 1, unit: 'lb', section: 'Meat' },
+      { name: 'lettuce', quantity: 1, unit: 'head', section: 'Produce' },
+      { name: 'tomatoes', quantity: 2, unit: 'pcs', section: 'Produce' },
+    ],
+    tags: ['gluten-free'],
+  },
+  {
+    id: 'r3',
+    title: 'Pasta Primavera',
+    ingredients: [
+      { name: 'pasta', quantity: 1, unit: 'box', section: 'Grains', allergens: ['gluten'] },
+      { name: 'tomato sauce', quantity: 1, unit: 'jar', section: 'Canned' },
+      { name: 'vegetables', quantity: 3, unit: 'cups', section: 'Produce' },
+    ],
+    tags: [],
+  },
 ];
 
 export async function generateMealPlan(constraints: string): Promise<MealPlan> {
@@ -30,7 +65,7 @@ export async function generateMealPlan(constraints: string): Promise<MealPlan> {
     if (process.env.OPENAI_API_KEY) {
       const response = await openai.responses.create({
         model: 'gpt-4o-mini',
-        input: `Create a 7 day meal plan with breakfast, lunch and dinner for each day. Respect these dietary constraints: ${constraints}. Return JSON in format { days: [ { day: "Monday", meals: { breakfast: { title: string, ingredients: string[] }, lunch: {...}, dinner: {...} } } ] }`,
+        input: `Create a 7 day meal plan with breakfast, lunch and dinner for each day. Respect these dietary constraints: ${constraints}. Return JSON in format { days: [ { day: "Monday", meals: { breakfast: { title: string, ingredients: [{name, quantity, unit?, section?, allergens?: string[]}] }, lunch: {...}, dinner: {...} } } ] }`,
       });
       const text = (response as any).output_text || (response as any).choices?.[0]?.message?.content || '{}';
       const json = JSON.parse(text);
@@ -57,13 +92,43 @@ export async function generateMealPlan(constraints: string): Promise<MealPlan> {
   }));
 }
 
-export function calculateShoppingList(plan: MealPlan): string[] {
-  const items = new Set<string>();
+export interface ShoppingItem {
+  name: string;
+  quantity: number;
+  unit?: string;
+  allergens?: string[];
+}
+
+export type ShoppingList = Record<string, ShoppingItem[]>; // section -> items
+
+export function calculateShoppingList(plan: MealPlan): ShoppingList {
+  const bySection: Record<string, Record<string, ShoppingItem>> = {};
+
   plan.forEach((day) => {
     MEAL_SLOTS.forEach((slot) => {
       const recipe = day.meals[slot];
-      recipe?.ingredients.forEach((ing) => items.add(ing));
+      recipe?.ingredients.forEach((ing) => {
+        const section = ing.section || 'Other';
+        bySection[section] ||= {};
+        const existing = bySection[section][ing.name];
+        if (existing) {
+          existing.quantity += ing.quantity;
+        } else {
+          bySection[section][ing.name] = {
+            name: ing.name,
+            quantity: ing.quantity,
+            unit: ing.unit,
+            allergens: ing.allergens,
+          };
+        }
+      });
     });
   });
-  return Array.from(items);
+
+  const result: ShoppingList = {};
+  Object.entries(bySection).forEach(([section, items]) => {
+    result[section] = Object.values(items);
+  });
+
+  return result;
 }

--- a/src/lib/pantry.ts
+++ b/src/lib/pantry.ts
@@ -1,0 +1,40 @@
+export interface PantryItem {
+  name: string;
+  quantity: number;
+  unit?: string;
+  section?: string;
+  allergens?: string[];
+}
+
+export function addToPantry(
+  pantry: PantryItem[],
+  items: PantryItem[],
+): PantryItem[] {
+  const map = new Map<string, PantryItem>();
+  pantry.forEach((p) => map.set(p.name, { ...p }));
+  items.forEach((item) => {
+    const existing = map.get(item.name);
+    if (existing) {
+      existing.quantity += item.quantity;
+    } else {
+      map.set(item.name, { ...item });
+    }
+  });
+  return Array.from(map.values());
+}
+
+export function getAllergenWarnings(
+  pantry: PantryItem[],
+  allergens: string[],
+): { item: PantryItem; allergens: string[] }[] {
+  const warnings: { item: PantryItem; allergens: string[] }[] = [];
+  pantry.forEach((item) => {
+    const found = item.allergens?.filter((a) =>
+      allergens.includes(a.toLowerCase()),
+    );
+    if (found && found.length) {
+      warnings.push({ item, allergens: found });
+    }
+  });
+  return warnings;
+}


### PR DESCRIPTION
## Summary
- expand meal plan ingredients with metadata and group shopping lists by store section
- add pantry utilities with allergen warnings and simple UI page

## Testing
- `npm run lint` (fails: next not found)
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68961b4c21a8832e975f659e07e1cd16