### PR TITLE
feat: add accessible cooking mode with i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "openai": "^4.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "next-intl": "^3.8.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",

--- a/src/app/(app)/recipes/sample/cook/page.tsx
+++ b/src/app/(app)/recipes/sample/cook/page.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import { CookingMode } from '@/components/cooking-mode';
+import { useTranslations, useLocale } from 'next-intl';
+import { convert, formatUnit } from '@/lib/units';
 
 const steps = [
   'Gather ingredients.',
@@ -8,9 +12,16 @@ const steps = [
 ];
 
 export default function SampleCookPage() {
+  const t = useTranslations('cook');
+  const locale = useLocale();
+  const amount =
+    locale === 'en'
+      ? formatUnit(1, 'cup', locale)
+      : formatUnit(convert(1, 'cup', 'ml'), 'ml', locale);
   return (
     <main className="p-4 sm:p-8 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Cooking Mode</h1>
+      <h1 className="text-2xl font-bold mb-4">{t('title')}</h1>
+      <p className="mb-4 text-sm text-gray-600">{t('unitExample', { amount })}</p>
       <CookingMode steps={steps} />
     </main>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import type { NextWebVitalsMetric } from 'next/app';
 import Providers from './providers';
+import { NextIntlClientProvider } from 'next-intl';
+import en from '@/messages/en.json';
 
 export const metadata = {
   title: 'Health Craft',
@@ -11,14 +13,18 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const locale = 'en';
+  const messages = en;
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#1e90ff" />
       </head>
       <body className="min-h-screen bg-white">
-        <Providers>{children}</Providers>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <Providers>{children}</Providers>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/src/components/cooking-mode.tsx
+++ b/src/components/cooking-mode.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useVoiceCommands } from '@/hooks/use-voice-commands';
 import { useDeviceCapabilities } from '@/hooks/use-device-capabilities';
+import { useTranslations } from 'next-intl';
 
 interface CookingModeProps {
   steps: string[];
@@ -11,26 +12,55 @@ interface CookingModeProps {
 
 export function CookingMode({ steps }: CookingModeProps) {
   const [index, setIndex] = useState(0);
+  const [voiceEnabled, setVoiceEnabled] = useState(false);
   const { voice } = useDeviceCapabilities();
+  const t = useTranslations('cook');
 
   const next = () => setIndex((i) => Math.min(i + 1, steps.length - 1));
   const prev = () => setIndex((i) => Math.max(i - 1, 0));
 
-  useVoiceCommands({ onNext: next, onPrevious: prev });
+  useVoiceCommands({ onNext: next, onPrevious: prev }, voiceEnabled);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') next();
+      if (e.key === 'ArrowLeft') prev();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [next, prev]);
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <div className="text-center text-xl min-h-[4rem] flex items-center">{steps[index]}</div>
+      <div
+        className="text-center text-xl min-h-[4rem] flex items-center"
+        role="status"
+        aria-live="polite"
+      >
+        {steps[index]}
+      </div>
       <div className="flex gap-2">
         <Button onClick={prev} disabled={index === 0}>
-          Previous
+          {t('previous')}
         </Button>
         <Button onClick={next} disabled={index === steps.length - 1}>
-          Next
+          {t('next')}
         </Button>
       </div>
       {voice && (
-        <p className="text-sm text-gray-500">Voice commands enabled: say "next" or "previous".</p>
+        <Button
+          variant="outline"
+          onClick={() => setVoiceEnabled((v) => !v)}
+          aria-pressed={voiceEnabled}
+          aria-label={voiceEnabled ? t('disableVoice') : t('enableVoice')}
+        >
+          {voiceEnabled ? t('disableVoice') : t('enableVoice')}
+        </Button>
+      )}
+      {voice && voiceEnabled && (
+        <p className="text-sm text-gray-500" aria-live="polite">
+          {t('voiceHint')}
+        </p>
       )}
     </div>
   );

--- a/src/hooks/use-voice-commands.ts
+++ b/src/hooks/use-voice-commands.ts
@@ -7,9 +7,15 @@ interface VoiceCommandHandlers {
   onPrevious?: () => void;
 }
 
-export function useVoiceCommands(handlers: VoiceCommandHandlers) {
+export function useVoiceCommands(
+  handlers: VoiceCommandHandlers,
+  enabled: boolean
+) {
   useEffect(() => {
-    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!enabled) return;
+    const SpeechRecognition =
+      (window as any).SpeechRecognition ||
+      (window as any).webkitSpeechRecognition;
     if (!SpeechRecognition) return;
 
     const recognition: SpeechRecognition = new SpeechRecognition();
@@ -21,10 +27,11 @@ export function useVoiceCommands(handlers: VoiceCommandHandlers) {
         .trim()
         .toLowerCase();
       if (transcript.includes('next')) handlers.onNext?.();
-      if (transcript.includes('previous') || transcript.includes('back')) handlers.onPrevious?.();
+      if (transcript.includes('previous') || transcript.includes('back'))
+        handlers.onPrevious?.();
     };
 
     recognition.start();
     return () => recognition.stop();
-  }, [handlers]);
+  }, [handlers, enabled]);
 }

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,3 @@
+export const locales = ['en', 'es'] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = 'en';

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,17 @@
+export type Unit = 'g' | 'oz' | 'ml' | 'cup';
+
+const GRAMS_PER_OUNCE = 28.3495;
+const ML_PER_CUP = 240;
+
+export function convert(value: number, from: Unit, to: Unit): number {
+  if (from === to) return value;
+  if (from === 'g' && to === 'oz') return value / GRAMS_PER_OUNCE;
+  if (from === 'oz' && to === 'g') return value * GRAMS_PER_OUNCE;
+  if (from === 'ml' && to === 'cup') return value / ML_PER_CUP;
+  if (from === 'cup' && to === 'ml') return value * ML_PER_CUP;
+  return value;
+}
+
+export function formatUnit(value: number, unit: Unit, locale: string) {
+  return `${new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(value)} ${unit}`;
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,0 +1,11 @@
+{
+  "cook": {
+    "title": "Cooking Mode",
+    "previous": "Previous",
+    "next": "Next",
+    "enableVoice": "Enable voice",
+    "disableVoice": "Disable voice",
+    "voiceHint": "Voice commands enabled: say 'next' or 'previous'.",
+    "unitExample": "Sample measurement: {amount}"
+  }
+}

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -1,0 +1,11 @@
+{
+  "cook": {
+    "title": "Modo de Cocina",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "enableVoice": "Activar voz",
+    "disableVoice": "Desactivar voz",
+    "voiceHint": "Comandos de voz activados: di 'siguiente' o 'anterior'.",
+    "unitExample": "Medición de ejemplo: {amount}"
+  }
+}


### PR DESCRIPTION
## Summary
- add NextIntl provider and translations for English and Spanish
- enhance CookingMode with keyboard navigation, ARIA live regions and optional voice commands
- add unit conversion helpers and sample localized measurement

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68962ec30c58832e8dbd79f7c62aee07