### PR TITLE
feat: add foundational UI components

### DIFF
--- a/src/components/device-action-bar.tsx
+++ b/src/components/device-action-bar.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface DeviceActionBarProps {
+  children: React.ReactNode;
+}
+
+export function DeviceActionBar({ children }: DeviceActionBarProps) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 flex justify-around border-t bg-white p-2">
+      {children}
+    </div>
+  );
+}
+

--- a/src/components/ingredient-list.tsx
+++ b/src/components/ingredient-list.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export interface Ingredient {
+  name: string;
+  quantity?: string;
+  unit?: string;
+}
+
+export interface IngredientListProps {
+  ingredients: Ingredient[];
+}
+
+export function IngredientList({ ingredients }: IngredientListProps) {
+  return (
+    <ul className="ml-4 list-disc space-y-1 text-sm">
+      {ingredients.map((ing, idx) => (
+        <li key={idx}>
+          {ing.quantity && <span>{ing.quantity} </span>}
+          {ing.unit && <span>{ing.unit} </span>}
+          <span>{ing.name}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/components/nl-prompt-editor.tsx
+++ b/src/components/nl-prompt-editor.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export interface NLPromptEditorProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export function NLPromptEditor({ className = '', ...props }: NLPromptEditorProps) {
+  return (
+    <textarea
+      className={`w-full border px-2 py-1 ${className}`}
+      rows={4}
+      {...props}
+    />
+  );
+}
+

--- a/src/components/pantry-editor.tsx
+++ b/src/components/pantry-editor.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+
+export interface PantryItem {
+  name: string;
+  quantity?: string;
+}
+
+export interface PantryEditorProps {
+  items: PantryItem[];
+  onChange?: (items: PantryItem[]) => void;
+}
+
+export function PantryEditor({ items, onChange }: PantryEditorProps) {
+  const [localItems, setLocalItems] = React.useState(items);
+
+  const updateItem = (
+    index: number,
+    field: keyof PantryItem,
+    value: string
+  ) => {
+    const next = [...localItems];
+    next[index] = { ...next[index], [field]: value };
+    setLocalItems(next);
+    onChange?.(next);
+  };
+
+  return (
+    <div className="space-y-2">
+      {localItems.map((item, idx) => (
+        <div key={idx} className="flex gap-2">
+          <input
+            className="flex-1 border px-2 py-1"
+            value={item.name}
+            onChange={(e) => updateItem(idx, 'name', e.target.value)}
+          />
+          <input
+            className="w-24 border px-2 py-1"
+            value={item.quantity ?? ''}
+            onChange={(e) => updateItem(idx, 'quantity', e.target.value)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/plan-grid.tsx
+++ b/src/components/plan-grid.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+export interface PlanGridProps {
+  slots: React.ReactNode[];
+  columns?: number;
+}
+
+export function PlanGrid({ slots, columns = 7 }: PlanGridProps) {
+  return (
+    <div
+      className="grid gap-2"
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {slots.map((slot, idx) => (
+        <div key={idx} className="border p-2">
+          {slot}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/recipe-card.tsx
+++ b/src/components/recipe-card.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { TagChip } from '@/components/tag-chip';
+
+export interface RecipeCardProps {
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  tags?: string[];
+}
+
+export function RecipeCard({ title, description, imageUrl, tags = [] }: RecipeCardProps) {
+  return (
+    <div className="overflow-hidden rounded border bg-white">
+      {imageUrl && <img src={imageUrl} alt={title} className="h-40 w-full object-cover" />}
+      <div className="p-4">
+        <h3 className="mb-2 text-lg font-semibold">{title}</h3>
+        {description && <p className="mb-2 text-sm text-gray-700">{description}</p>}
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <TagChip key={tag} tag={tag} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/recipe-drawer.tsx
+++ b/src/components/recipe-drawer.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import * as React from 'react';
+
+export interface RecipeDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function RecipeDrawer({ open, onClose, children }: RecipeDrawerProps) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex bg-black/50"
+      onClick={onClose}
+    >
+      <aside
+        className="ml-auto h-full w-80 overflow-y-auto bg-white p-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </aside>
+    </div>
+  );
+}
+

--- a/src/components/shopping-list.tsx
+++ b/src/components/shopping-list.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import * as React from 'react';
+
+export interface ShoppingItem {
+  name: string;
+  checked?: boolean;
+}
+
+export interface ShoppingListProps {
+  items: ShoppingItem[];
+  onChange?: (items: ShoppingItem[]) => void;
+}
+
+export function ShoppingList({ items, onChange }: ShoppingListProps) {
+  const [localItems, setLocalItems] = React.useState(items);
+
+  const toggle = (index: number) => {
+    const next = [...localItems];
+    next[index].checked = !next[index].checked;
+    setLocalItems(next);
+    onChange?.(next);
+  };
+
+  return (
+    <ul className="space-y-1">
+      {localItems.map((item, idx) => (
+        <li key={idx} className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={item.checked ?? false}
+            onChange={() => toggle(idx)}
+          />
+          <span className={item.checked ? 'line-through' : ''}>{item.name}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/components/step-list.tsx
+++ b/src/components/step-list.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface StepListProps {
+  steps: string[];
+}
+
+export function StepList({ steps }: StepListProps) {
+  return (
+    <ol className="ml-4 list-decimal space-y-1 text-sm">
+      {steps.map((step, idx) => (
+        <li key={idx}>{step}</li>
+      ))}
+    </ol>
+  );
+}
+

--- a/src/components/tag-chip.tsx
+++ b/src/components/tag-chip.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface TagChipProps {
+  tag: string;
+}
+
+export function TagChip({ tag }: TagChipProps) {
+  return (
+    <span className="inline-block rounded bg-gray-200 px-2 py-1 text-xs text-gray-700">
+      {tag}
+    </span>
+  );
+}
+

--- a/src/components/timer.tsx
+++ b/src/components/timer.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import * as React from 'react';
+
+export interface TimerProps {
+  initialSeconds: number;
+}
+
+export function Timer({ initialSeconds }: TimerProps) {
+  const [seconds, setSeconds] = React.useState(initialSeconds);
+
+  React.useEffect(() => {
+    if (seconds <= 0) return;
+    const id = setInterval(() => {
+      setSeconds((s) => (s > 0 ? s - 1 : 0));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [seconds]);
+
+  const minutes = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const secs = (seconds % 60).toString().padStart(2, '0');
+
+  return <div className="font-mono text-xl">{minutes}:{secs}</div>;
+}
+

--- a/src/components/upload-dropzone.tsx
+++ b/src/components/upload-dropzone.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+
+export interface UploadDropzoneProps {
+  onFiles: (files: FileList) => void;
+}
+
+export function UploadDropzone({ onFiles }: UploadDropzoneProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) onFiles(e.target.files);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) onFiles(e.dataTransfer.files);
+  };
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      className="flex flex-col items-center justify-center rounded border-2 border-dashed p-6 text-center"
+    >
+      <p className="mb-2 text-sm text-gray-600">
+        Drag and drop files here or click to browse
+      </p>
+      <input type="file" multiple onChange={handleChange} />
+    </div>
+  );
+}
+

--- a/src/components/url-input.tsx
+++ b/src/components/url-input.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export interface URLInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export function URLInput({ className = '', ...props }: URLInputProps) {
+  return (
+    <input
+      type="url"
+      className={`w-full border px-2 py-1 ${className}`}
+      {...props}
+    />
+  );
+}
+

--- a/src/components/voice-button.tsx
+++ b/src/components/voice-button.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+
+export interface VoiceButtonProps {
+  onToggle?: (listening: boolean) => void;
+}
+
+export function VoiceButton({ onToggle }: VoiceButtonProps) {
+  const [listening, setListening] = React.useState(false);
+
+  const toggle = () => {
+    const next = !listening;
+    setListening(next);
+    onToggle?.(next);
+  };
+
+  return <Button onClick={toggle}>{listening ? 'Stop' : 'Speak'}</Button>;
+}
+


### PR DESCRIPTION
## Summary
- scaffold core UI primitives like recipe cards, ingredient lists, timers, and planners
- add interactive helpers including voice button, upload dropzone, and device action bar

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689642a5addc832ea88fb1018ead2561