### PR TITLE
Fix Sentry setup by using instrumentation hook and add global error boundary

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,6 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,6 +1,0 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="flex min-h-screen items-center justify-center bg-white px-4">
+        <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-8 text-center shadow-lg">
+          <h1 className="text-2xl font-semibold text-gray-900">Something went wrong</h1>
+          <p className="mt-4 text-sm text-gray-600">
+            We&apos;ve recorded the error and our team will look into it.
+          </p>
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="mt-6 inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/nextjs';
+
+export function register() {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  });
+}


### PR DESCRIPTION
## Summary
- move Sentry server and edge initialization into the Next.js instrumentation hook
- add a global error boundary component that reports to Sentry and offers a retry action
- remove the deprecated server and edge Sentry config files

## Testing
- yarn lint *(fails: requires installing dependencies, which is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf796fd08832eb4e118585ab3a116