### PR TITLE
Fix marketing page counter import

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,7 +1,5 @@
 import Image from 'next/image';
-import dynamic from 'next/dynamic';
-
-const Counter = dynamic(() => import('@/components/counter'), { ssr: false });
+import { Counter } from '@/components/counter';
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- replace the dynamic counter import with a direct client component import on the marketing page

## Testing
- yarn lint *(fails: dependency installation blocked by network 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf889f8d0832eb115b000dba562ca