### PR TITLE
Add next-intl configuration

### DIFF
--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,0 +1,6 @@
+import { defaultLocale, locales } from './src/i18n/config';
+
+export default {
+  locales,
+  defaultLocale,
+};


### PR DESCRIPTION
## Summary
- add the required `next-intl.config.ts` file so Next.js can locate the locale settings

## Testing
- yarn lint *(fails: missing node_modules state file in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf95b3d50832e80008199e72c8423