### PR TITLE
Configure next-intl plugin

### DIFF
--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,6 +1,6 @@
-import { defaultLocale, locales } from './src/i18n/config';
+import { defineRouting } from 'next-intl/routing';
 
-export default {
-  locales,
-  defaultLocale,
-};
+export default defineRouting({
+  locales: ['en', 'es'],
+  defaultLocale: 'en',
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,7 @@
+import createNextIntlPlugin from 'next-intl/plugin';
 import { withSentryConfig } from '@sentry/nextjs';
+
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -15,4 +18,4 @@ const nextConfig = {
   },
 };
 
-export default withSentryConfig(nextConfig, { silent: true });
+export default withSentryConfig(withNextIntl(nextConfig), { silent: true });

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,26 @@
+import { getRequestConfig } from 'next-intl/server';
+import { defaultLocale, locales } from './config';
+
+type SupportedLocale = (typeof locales)[number];
+
+async function loadMessages(locale: SupportedLocale) {
+  const messages = await import(`../messages/${locale}.json`);
+  return messages.default;
+}
+
+function resolveLocale(locale?: string): SupportedLocale {
+  if (locale && locales.includes(locale as SupportedLocale)) {
+    return locale as SupportedLocale;
+  }
+  return defaultLocale;
+}
+
+export default getRequestConfig(async ({ locale }) => {
+  const resolvedLocale = resolveLocale(locale);
+  const messages = await loadMessages(resolvedLocale);
+
+  return {
+    locale: resolvedLocale,
+    messages,
+  };
+});


### PR DESCRIPTION
## Summary
- wire up next-intl's routing config so the framework can discover supported locales
- add request configuration for loading locale messages and compose it with the Next.js config

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfcaf9658832ebd96e035706d39d1