### PR TITLE
Use next-intl request helper for locale detection

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import type { NextWebVitalsMetric } from 'next/app';
-import { headers } from 'next/headers';
 import { NextIntlClientProvider } from 'next-intl';
-import { setRequestLocale } from 'next-intl/server';
+import { getRequestLocale, setRequestLocale } from 'next-intl/server';
 import Providers from './providers';
 import { defaultLocale, locales, type Locale } from '@/i18n/config';
 
@@ -27,8 +26,7 @@ export const metadata = {
 };
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
-  const headersList = await headers();
-  const requestedLocale = headersList.get('X-NEXT-INTL-LOCALE');
+  const requestedLocale = await getRequestLocale();
   const locale = resolveLocale(requestedLocale);
   setRequestLocale(locale);
   const messages = await loadMessages(locale);


### PR DESCRIPTION
## Summary
- replace direct header access in the root layout with next-intl's `getRequestLocale`
- keep locale resolution logic while ensuring the request locale is retrieved asynchronously

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cc13624518832eb922fb3fbbdf8383