### PR TITLE
Fix next-intl locale retrieval in layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import type { NextWebVitalsMetric } from 'next/app';
 import { NextIntlClientProvider } from 'next-intl';
-import { getRequestLocale, setRequestLocale } from 'next-intl/server';
+import { getLocale, setRequestLocale } from 'next-intl/server';
 import Providers from './providers';
 import { defaultLocale, locales, type Locale } from '@/i18n/config';
 
@@ -26,7 +26,7 @@ export const metadata = {
 };
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
-  const requestedLocale = await getRequestLocale();
+  const requestedLocale = await getLocale();
   const locale = resolveLocale(requestedLocale);
   setRequestLocale(locale);
   const messages = await loadMessages(locale);


### PR DESCRIPTION
## Summary
- switch RootLayout to use `getLocale` from `next-intl/server`
- prevent runtime TypeError caused by the removed `getRequestLocale` export

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cc48ec626c832eb2e7c49573a01d15