### PR TITLE
Fix locale handling in middleware to avoid root layout notFound error

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,24 +1,37 @@
+import createMiddleware from 'next-intl/middleware';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { defaultLocale, locales } from '@/i18n/config';
 
 const WINDOW_MS = 60 * 1000;
 const MAX_REQ = 60;
 const ipMap = new Map<string, { count: number; start: number }>();
 
+const intlMiddleware = createMiddleware({
+  locales,
+  defaultLocale,
+});
+
 export function middleware(req: NextRequest) {
-  const ip = req.ip ?? '127.0.0.1';
-  const now = Date.now();
-  const record = ipMap.get(ip) || { count: 0, start: now };
-  if (now - record.start > WINDOW_MS) {
-    record.count = 0;
-    record.start = now;
+  if (req.nextUrl.pathname.startsWith('/api/')) {
+    const ip = req.ip ?? '127.0.0.1';
+    const now = Date.now();
+    const record = ipMap.get(ip) || { count: 0, start: now };
+    if (now - record.start > WINDOW_MS) {
+      record.count = 0;
+      record.start = now;
+    }
+    record.count++;
+    ipMap.set(ip, record);
+    if (record.count > MAX_REQ) {
+      return new NextResponse('Too Many Requests', { status: 429 });
+    }
+    return NextResponse.next();
   }
-  record.count++;
-  ipMap.set(ip, record);
-  if (record.count > MAX_REQ) {
-    return new NextResponse('Too Many Requests', { status: 429 });
-  }
-  return NextResponse.next();
+
+  return intlMiddleware(req);
 }
 
-export const config = { matcher: '/api/:path*' };
+export const config = {
+  matcher: ['/(?!api|_next|_vercel|.*\\..*).*', '/api/:path*'],
+};


### PR DESCRIPTION
## Summary
- integrate next-intl middleware so non-API routes have the locale set before reaching the app
- preserve the existing API rate limiting logic while bypassing i18n handling for API requests
- expand the middleware matcher to cover both API and non-API routes appropriately

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4b4c11b4832ea1c4582f146759b3