### PR TITLE
Fix not-found locale handling for Next 15 headers API

### DIFF
--- a/src/app/_not-found.tsx
+++ b/src/app/_not-found.tsx
@@ -1,0 +1,37 @@
+import { headers } from 'next/headers';
+import { NextIntlClientProvider } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
+
+import Providers from './providers';
+import { resolveLocale, loadMessages } from '@/i18n/server-utils';
+import type { Locale } from '@/i18n/config';
+
+async function getLocaleFromHeaders(): Promise<Locale> {
+  const headerList = await headers();
+  const requestedLocale = headerList.get('X-NEXT-INTL-LOCALE');
+
+  return resolveLocale(requestedLocale);
+}
+
+export default async function NotFoundPage() {
+  const locale = await getLocaleFromHeaders();
+  setRequestLocale(locale);
+  const messages = await loadMessages(locale);
+
+  return (
+    <html lang={locale}>
+      <body className="min-h-screen bg-white">
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <Providers>
+            <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6 text-center">
+              <h1 className="text-3xl font-semibold">Page not found</h1>
+              <p className="max-w-md text-muted-foreground">
+                The page you are looking for might have been removed, had its name changed or is temporarily unavailable.
+              </p>
+            </main>
+          </Providers>
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,19 +4,7 @@ import type { NextWebVitalsMetric } from 'next/app';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, setRequestLocale } from 'next-intl/server';
 import Providers from './providers';
-import { defaultLocale, locales, type Locale } from '@/i18n/config';
-
-async function loadMessages(locale: Locale) {
-  const messages = await import(`@/messages/${locale}.json`);
-  return messages.default;
-}
-
-function resolveLocale(locale?: string | null): Locale {
-  if (locale && locales.includes(locale as Locale)) {
-    return locale as Locale;
-  }
-  return defaultLocale;
-}
+import { resolveLocale, loadMessages } from '@/i18n/server-utils';
 
 export const metadata = {
   title: 'Health Craft',

--- a/src/i18n/server-utils.ts
+++ b/src/i18n/server-utils.ts
@@ -1,0 +1,14 @@
+import { defaultLocale, locales, type Locale } from './config';
+
+export async function loadMessages(locale: Locale) {
+  const messages = await import(`@/messages/${locale}.json`);
+  return messages.default;
+}
+
+export function resolveLocale(locale?: string | null): Locale {
+  if (locale && locales.includes(locale as Locale)) {
+    return locale as Locale;
+  }
+
+  return defaultLocale;
+}


### PR DESCRIPTION
## Summary
- refactor locale utilities into a shared helper for layouts and error routes
- add a custom `_not-found` route that awaits the headers API, sets the locale and renders a basic 404 view

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cc590b2bf4832eb21a89017f32b322