### PR TITLE
Fix locale detection in not-found route

### DIFF
--- a/src/app/_not-found.tsx
+++ b/src/app/_not-found.tsx
@@ -1,20 +1,12 @@
-import { headers } from 'next/headers';
 import { NextIntlClientProvider } from 'next-intl';
-import { setRequestLocale } from 'next-intl/server';
+import { getLocale, setRequestLocale } from 'next-intl/server';
 
 import Providers from './providers';
 import { resolveLocale, loadMessages } from '@/i18n/server-utils';
-import type { Locale } from '@/i18n/config';
-
-async function getLocaleFromHeaders(): Promise<Locale> {
-  const headerList = await headers();
-  const requestedLocale = headerList.get('X-NEXT-INTL-LOCALE');
-
-  return resolveLocale(requestedLocale);
-}
 
 export default async function NotFoundPage() {
-  const locale = await getLocaleFromHeaders();
+  const requestedLocale = await getLocale();
+  const locale = resolveLocale(requestedLocale);
   setRequestLocale(locale);
   const messages = await loadMessages(locale);
 


### PR DESCRIPTION
## Summary
- switch the not-found route to use next-intl's getLocale helper
- remove direct access to request headers to avoid runtime errors when resolving the locale

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd47feb30c832eb81bd0ad04751def